### PR TITLE
feat(webserverrunner): expose server certificate validation as config param

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,11 @@
                         "envFile": {
                             "type": "string",
                             "description": "Specifies the path to an environment file"
+                        },
+                        "certificateValidation": {
+                            "type": "boolean",
+                            "default": true,
+                            "description": "Specifies whether to validate the Credential Digger webserver certificate"
                         }
                     }
                 }

--- a/src/lib/client/runner/webserver-runner.ts
+++ b/src/lib/client/runner/webserver-runner.ts
@@ -21,7 +21,7 @@ import {
 } from '../../../types/config';
 import { Discovery } from '../../../types/db';
 import LoggerFactory from '../../logger-factory';
-import { convertRawToDiscovery } from '../../utils';
+import { convertRawToDiscovery, isNullOrUndefined } from '../../utils';
 
 export default class WebServerRunner extends Runner {
     private discoveries: Discovery[] = [];
@@ -38,8 +38,20 @@ export default class WebServerRunner extends Runner {
         // Create httpsAgent
         let httpsAgent;
         if (this.config.host.startsWith('https')) {
+            let certificateValidation = true;
+            if (isNullOrUndefined(this.config.certificateValidation)) {
+                LoggerFactory.getInstance().warn(
+                    `Certificate validation flag is not set defaulting to ${certificateValidation}`,
+                );
+            } else {
+                certificateValidation = this.config
+                    .certificateValidation as boolean;
+                LoggerFactory.getInstance().warn(
+                    `Certificate validation flag is set to ${certificateValidation}`,
+                );
+            }
             httpsAgent = new Agent({
-                rejectUnauthorized: false,
+                rejectUnauthorized: certificateValidation,
             });
         }
         // Create httpInstance

--- a/src/test/unit/utils.ts
+++ b/src/test/unit/utils.ts
@@ -81,8 +81,9 @@ export function generateCredentialDiggerRunnerConfig(
             return {
                 type: CredentialDiggerRuntime.WebServer,
                 webserver: {
-                    host: faker.internet.url(),
+                    host: faker.internet.url({ protocol: 'http' }),
                     envFile: faker.system.filePath(),
+                    certificateValidation: false,
                 },
             };
         default:

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -47,6 +47,7 @@ export interface CredentialDiggerRunnerBinaryConfig {
 export interface CredentialDiggerRunnerWebServerConfig {
     host: string;
     envFile?: string;
+    certificateValidation?: boolean;
 }
 
 export type CredentialDiggerRunnerConfig =


### PR DESCRIPTION

`certificateValidation` could be set to enable/disable the webserver certificate validation

BREAKING CHANGE: For the credential digger running in a webserver, the server certificate will be validated by default.

fix #51